### PR TITLE
Update Approov service layer to latest published versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The Approov integration is available via [`maven`](https://mvnrepository.com/rep
 The `Maven` repository is already present in the gradle.build file so the only import you need to make is the actual service layer itself:
 
 ```
-implementation("io.approov:service.httpsurlconn:3.5.3")
+implementation("io.approov:service.httpsurlconn:3.5.4")
 ```
 
 Make sure you do a Gradle sync (by selecting `Sync Now` in the banner at the top of the modified `.gradle` file) after making these changes.

--- a/SHAPES-EXAMPLE.md
+++ b/SHAPES-EXAMPLE.md
@@ -45,7 +45,7 @@ The `approov-service-httpsurlconn` dependency needs to be added as follows to th
 ![App Build Gradle](readme-images/app-gradle.png)
 
 ```
-implementation("io.approov:service.httpsurlconn:3.5.3")
+implementation("io.approov:service.httpsurlconn:3.5.4")
 ```
 
 Make sure you do a Gradle sync (by selecting `Sync Now` in the banner at the top of the modified `.gradle` file) after making these changes.


### PR DESCRIPTION
- `io.approov:service.httpsurlconn` **3.5.3 → 3.5.4** (latest on Maven Central) in `README.md` and `SHAPES-EXAMPLE.md`.


All referenced versions were verified to resolve (HTTP 200 on the Maven Central POM / pub.dev API) before committing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
